### PR TITLE
✨ (catalog): Add a Kairos bundle to sync a flux repository

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -29,27 +29,27 @@ const types = [
 	{
 		value: ":alembic:",
 		emoji: "⚗️",
-		name: ":alembic:                   ⚗️   Perform experiments.",
+		name: ":alembic:                   ⚗️  Perform experiments.",
 	},
 	{
 		value: ":alien:",
 		emoji: "👽️",
-		name: ":alien:                     👽️  Update code due to external API changes.",
+		name: ":alien:                     👽️ Update code due to external API changes.",
 	},
 	{
 		value: ":ambulance:",
 		emoji: "🚑️",
-		name: ":ambulance:                 🚑️  Critical hotfix.",
+		name: ":ambulance:                 🚑️ Critical hotfix.",
 	},
 	{
 		value: ":arrow_down:",
 		emoji: "⬇️",
-		name: ":arrow_down:                ⬇️   Downgrade dependencies.",
+		name: ":arrow_down:                ⬇️  Downgrade dependencies.",
 	},
 	{
 		value: ":arrow_up:",
 		emoji: "⬆️",
-		name: ":arrow_up:                  ⬆️   Upgrade dependencies.",
+		name: ":arrow_up:                  ⬆️  Upgrade dependencies.",
 	},
 	{
 		value: ":art:",
@@ -84,7 +84,7 @@ const types = [
 	{
 		value: ":building_construction:",
 		emoji: "🏗️",
-		name: ":building_construction:     🏗️   Make architectural changes.",
+		name: ":building_construction:     🏗️  Make architectural changes.",
 	},
 	{
 		value: ":bulb:",
@@ -99,7 +99,7 @@ const types = [
 	{
 		value: ":coffin:",
 		emoji: "⚰️",
-		name: ":coffin:                    ⚰️   Remove dead code.",
+		name: ":coffin:                    ⚰️  Remove dead code.",
 	},
 	{
 		value: ":construction_worker:",
@@ -134,7 +134,7 @@ const types = [
 	{
 		value: ":label:",
 		emoji: "🏷️",
-		name: ":label:                     🏷️   Add or update types.",
+		name: ":label:                     🏷️  Add or update types.",
 	},
 	{
 		value: ":lipstick:",
@@ -144,7 +144,7 @@ const types = [
 	{
 		value: ":lock:",
 		emoji: "🔒️",
-		name: ":lock:                      🔒️  Fix security or privacy issues.",
+		name: ":lock:                      🔒️ Fix security or privacy issues.",
 	},
 	{
 		value: ":memo:",
@@ -154,7 +154,7 @@ const types = [
 	{
 		value: ":package:",
 		emoji: "📦️",
-		name: ":package:                   📦️  Add or update compiled files or packages.",
+		name: ":package:                   📦️ Add or update compiled files or packages.",
 	},
 	{
 		value: ":page_facing_up:",
@@ -169,7 +169,7 @@ const types = [
 	{
 		value: ":pencil2:",
 		emoji: "✏️",
-		name: ":pencil2:                   ✏️   Fix typos.",
+		name: ":pencil2:                   ✏️  Fix typos.",
 	},
 	{
 		value: ":pushpin:",
@@ -179,12 +179,12 @@ const types = [
 	{
 		value: ":recycle:",
 		emoji: "♻️",
-		name: ":recycle:                   ♻️   Refactor code.",
+		name: ":recycle:                   ♻️  Refactor code.",
 	},
 	{
 		value: ":rewind:",
 		emoji: "⏪️",
-		name: ":rewind:                    ⏪️  Revert changes.",
+		name: ":rewind:                    ⏪️ Revert changes.",
 	},
 	{
 		value: ":rocket:",
@@ -244,7 +244,7 @@ const types = [
 	{
 		value: ":wastebasket:",
 		emoji: "🗑️",
-		name: ":wastebasket:               🗑️   Deprecate code that needs to be cleaned up.",
+		name: ":wastebasket:               🗑️  Deprecate code that needs to be cleaned up.",
 	},
 	{
 		value: ":white_check_mark:",
@@ -259,7 +259,7 @@ const types = [
 	{
 		value: ":zap:",
 		emoji: "⚡️",
-		name: ":zap:                       ⚡️  Improve performance.",
+		name: ":zap:                       ⚡️ Improve performance.",
 	},
 ];
 
@@ -268,27 +268,31 @@ const types = [
  */
 const scopes = [
 	{
-		name: "catalog:crossplane - Anything related to the Crossplane resource catalog",
+		name: "catalog:crossplane    - Anything related to the Crossplane resource catalog",
 		value: "catalog:crossplane",
 	},
 	{
-		name: "catalog:flakes	- Anything related to the Nix flakes catalog",
+		name: "catalog:flakes        - Anything related to the Nix flakes catalog",
 		value: "catalog:flakes",
 	},
 	{
-		name: "project:chezmoi.sh - Anything related to the chezmoi.sh project",
+		name: "catalog:kairos-bundle - Anything related to the Kairos bundle catalog",
+		value: "catalog:kairos-bundle",
+	},
+	{
+		name: "project:chezmoi.sh    - Anything related to the chezmoi.sh project",
 		value: "project:chezmoi.sh",
 	},
 	{
-		name: "project:hass       - Anything related to the Home Assistant project",
+		name: "project:hass          - Anything related to the Home Assistant project",
 		value: "project:hass",
 	},
 	{
-		name: "project:nex·rpi    - Anything related to the Nex·RPI project (chezmoi.sh)",
+		name: "project:nex·rpi       - Anything related to the Nex·RPI project (chezmoi.sh)",
 		value: "project:nex·rpi",
 	},
 	{
-		name: "gh                 - Anything else",
+		name: "gh                    - Anything else",
 		value: "gh",
 	},
 ];

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,7 +22,7 @@ pr::dependencies:
   - head-branch:
       - ^renovate\/.+$
 
-pr:documentation:
+pr::documentation:
   - changed-files:
       - any-glob-to-any-file: [README.md, LICENSE, "**/README.md"]
 

--- a/.github/workflows/merge_group,pull_request.all.lint.yaml
+++ b/.github/workflows/merge_group,pull_request.all.lint.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: ⬇️ Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: ✏️ Overrides Trunk configuration for Github Action
-        run: mv .trunk/gha.yaml .trunk/user.yaml
+      # - name: ✏️ Overrides Trunk configuration for Github Action
+      #   run: mv .trunk/gha.yaml .trunk/user.yaml
       - name: ⚡️ Run `trunk check`
         uses: trunk-io/trunk-action@86b68ffae610a05105e90b1f52ad8c549ef482c2 # v1.1.16

--- a/.github/workflows/pull_request,push.kairos-bundles.yaml
+++ b/.github/workflows/pull_request,push.kairos-bundles.yaml
@@ -1,0 +1,72 @@
+---
+name: 📦 Build Kairos bundles
+
+on:
+  pull_request:
+    paths: ["catalog/kairos-bundles/**"]
+  push:
+    branches: [wip/iron-age] # default branch
+    paths: ["catalog/kairos-bundles/**"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  find_updated_apps:
+    name: 📄 List updated bundles
+    runs-on: ubuntu-latest
+    outputs:
+      updated_apps: ${{ steps.list_bundles.outputs.updated }}
+    steps:
+      - name: ⬇️ Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: 📄 List updated bundles
+        id: list_bundles
+        run: |
+          (
+            echo -n 'updated='
+            git diff --name-only "${FROM}" "${TO}" | grep 'catalog/kairos-bundles/' | cut -d'/' -f3 | sort --unique \
+            | jq --slurp --raw-input '. | split("\n") | map(select(. != ""))' --compact-output
+          ) >> "${GITHUB_OUTPUT}"
+        env:
+          FROM: ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }}
+          TO: ${{ github.event.pull_request.head.sha }}
+
+  build_bundle:
+    name: 🏗️ Build bundle (${{ matrix.bundle }})
+    needs: find_updated_apps
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bundle: ${{ fromJson(needs.find_updated_apps.outputs.updated_apps) }}
+    steps:
+      - name: ⬇️ Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: 🛠️ Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+      - name: 🛠️ Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+
+      - name: 🏗️ Build bundle (${{ matrix.bundle }})
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          annotations: |
+            org.opencontainers.image.title="${{ matrix.bundle }} (kairos bundle)"
+            org.opencontainers.image.source="https://${{ github.repository }}/blob/${{ github.sha }}/catalog/kairos-bundles/${{ matrix.bundle }}"
+            org.opencontainers.image.description="Kairos bundle for ${{ matrix.bundle }}"
+          context: catalog/kairos-bundles/${{ matrix.bundle }}
+          file: catalog/kairos-bundles/${{ matrix.bundle }}/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          provenance: mode=max
+          push: ${{ github.event_name == 'push' }}
+          sbom: true
+          tags: ghcr.io/${{ github.repository_owner }}/kairos-bundles:${{ matrix.bundle }}
+        env:
+          SOURCE_DATE_EPOCH: 0

--- a/catalog/kairos-bundles/flux-sync/Dockerfile
+++ b/catalog/kairos-bundles/flux-sync/Dockerfile
@@ -1,0 +1,13 @@
+# trunk-ignore-all(trivy/DS026,checkov/CKV_DOCKER_2,checkov/CKV_DOCKER_3,trivy/DS002)
+FROM docker.io/fluxcd/flux-cli:v2.4.0 AS flux-cli
+FROM scratch
+
+WORKDIR /
+COPY --from=flux-cli /usr/local/bin/flux .
+COPY flux-sync.service .
+COPY flux-sync.sh .
+COPY run.sh .
+
+LABEL org.opencontainers.image.source="https://github.com/chezmoi-sh/atlas/tree/wip/iron-age/catalog/kairos-bundles/flux-sync"
+LABEL org.opencontainers.image.description="Kairos Bundles to synchronize your Kubernetes cluster with your Git repository"
+LABEL org.opencontainers.image.licenses="Apache-2.0"

--- a/catalog/kairos-bundles/flux-sync/README.md
+++ b/catalog/kairos-bundles/flux-sync/README.md
@@ -1,0 +1,61 @@
+# Kairos Bundle - Flux synchronization
+
+> \[!CAUTION]
+> This bundle only works with a repository that has already been bootstrapped
+> with fluxcd. If you want to bootstrap a repository, I recommend using the
+> [flux-bootstrap](https://github.com/kairos-io/community-bundles/tree/main/flux)
+> bundle.
+
+This [Kairos bundle](https://kairos.io/docs/advanced/bundles/) is designed to
+synchronize your Kubernetes cluster state using [fluxcd](https://fluxcd.io/).
+
+It will install the fluxcd components inside `flux-system` namespace and will
+create a `GitRepository` and a `Kustomization` resource to sync the manifests
+from the repository you specify.
+
+## 📋 Requirements
+
+* A Kubernetes cluster created using [Kairos](https://kairos.io)
+* A repository already bootstrapped with fluxcd
+* `systemd` **must be** on nodes where this bundle is applied
+
+## 🚀 Usage
+
+To use this bundle, you need to specify the following parameters:
+
+```yaml
+bundles:
+  - targets:
+    - run://ghcr.io/chezmoi-sh/kairos-bundles:flux-sync
+
+flux:
+  git:
+    url: https://github.com/fluxcd/flux2-monitoring-example.git
+    branch: main # tag or tag_semver can also be used instead of branch
+    path: clusters/test
+  # source_git_extra_args: [] # Extra arguments to pass to the source git command (https://fluxcd.io/flux/cmd/flux_create_source_git/#options)
+  # kustomization_extra_args: [] # Extra arguments to pass to the kustomization command (https://fluxcd.io/flux/cmd/flux_create_kustomization/#options)
+```
+
+> \[!NOTE]
+> The `GitRepository` and `Kustomization` resources will be created in the
+> `flux-system` namespace and will be name `main`.
+
+### ⚙️ Parameters
+
+* **`flux.git.url`**: The URL of the git repository to sync.
+* **`flux.git.branch`**: The branch to sync.
+* **`flux.git.tag`**: The tag to sync.
+* **`flux.git.tag_semver`**: The tag to sync using semver.
+* **`flux.git.path`**: The path inside the repository to sync.
+* **`flux.source_git_extra_args`**: Extra arguments for the source git command. See [fluxcd documentation](https://fluxcd.io/flux/cmd/flux_create_source_git/#options) for more information.
+* **`flux.kustomization_extra_args`**: Extra arguments for the kustomization command. See [fluxcd documentation](https://fluxcd.io/flux/cmd/flux_create_kustomization/#options) for more information.
+
+> \[!WARNING]
+> Only one of `flux.git.branch`, `flux.git.tag`, or `flux.git.tag_semver` can be
+> used at a time.
+
+## 📄 License
+
+This bundle is licensed under the Apache-2.0 License. See the [LICENSE](../../../LICENSE) file
+for more information.

--- a/catalog/kairos-bundles/flux-sync/flux-sync.service
+++ b/catalog/kairos-bundles/flux-sync/flux-sync.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Synchronize your Kubernetes cluster state with Flux
+Documentation=https://github.com/kairos-io/community-bundles/blob/main/README.md#flux
+After=k3s.service
+
+[Service]
+Type=oneshot
+Restart=no
+ExecStart=/opt/kairos/bundles/flux-sync/flux-sync.sh
+User=root
+Group=root
+RemainAfterExit=yes
+
+[Install]
+WantedBy=k3s.service

--- a/catalog/kairos-bundles/flux-sync/flux-sync.sh
+++ b/catalog/kairos-bundles/flux-sync/flux-sync.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# trunk-ignore-all(shellcheck/SC2312): don't care of the return value
+set -euo pipefail
+
+# Override with the `flux.env.KUBECONFIG` key if necessary
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
+# -- Parameters
+lease_duration="30 minutes"
+wait_before_retry="15 seconds"
+
+# -- Functions
+info() { echo $'\e[36mINFO\e[0m: ' "$1"; }
+warn() { echo $'\e[33mWARN\e[0m:' "$1"; }
+error() { echo $'\e[31mERROR\e[0m:' "$1"; }
+
+# -- Main program
+total_attempts=$(($(date --date="0 - 1734566400 seconds + ${lease_duration}" +%s) / $(date --date="0 - 1734566400 seconds + ${wait_before_retry}" +%s)))
+retry_attempt=1
+while [[ ${retry_attempt} -le ${total_attempts} ]]; do
+	info "Checking if the cluster is ready"
+	if ! timeout 5 kubectl version &>/dev/null; then
+		error "Kubernetes cluster is not ready... retrying in 15 seconds"
+	else
+		# --- Step 01: Check if Flux is already installed and synced
+		if kubectl get namespace flux-system &>/dev/null; then
+			# NOTE: if this namespace already exists, we assume Flux is already installed by this bundle
+			#       with all the necessary resources
+			info "Namespace flux-system already exists, skipping..."
+			exit 0
+		fi
+
+		# --- Step 02: Create Lease to avoid concurrency issues
+		if ! kubectl get lease -n default flux-sync &>/dev/null; then
+			info "Creating lease for Flux sync to avoid concurrency ($(hostname))"
+			cat <<EOF | kubectl create -f -
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: flux-sync
+  namespace: default
+spec:
+  holderIdentity: $(hostname)
+  leaseDurationSeconds: $(date --date="0 - 1734566400 seconds + ${lease_duration}" +%s)
+  renewTime: $(date -u +"%Y-%m-%dT%H:%M:%S.000000Z" --date="now + ${lease_duration}")
+EOF
+
+			release_lease() { kubectl delete lease -n default flux-sync; } # trunk-ignore(shellcheck/SC2317): release_lease is used inside trap
+			trap release_lease EXIT
+		else
+			warn "Lease already exists, exiting..."
+			exit 0
+		fi
+
+		# --- Step 03: Create all resources required to sync FluxCD repository
+		source_git_url=$(kairos-agent config get flux.git.url)
+		source_git_branch=$(kairos-agent config get flux.git.branch)
+		source_git_tag=$(kairos-agent config get flux.git.tag)
+		source_git_tag_semver=$(kairos-agent config get flux.git.tag_semver)
+		source_git_path=$(kairos-agent config get flux.git.path)
+
+		[[ -z ${source_git_url} ]] && error "Missing required parameter 'flux.git.url'" && exit 1 # trunk-ignore(shellcheck/SC2310)
+		[[ -z ${source_git_branch} && -z ${source_git_tag} && -z ${source_git_tag_semver} ]] && source_git_branch="main"
+		[[ -n ${source_git_branch} && (-n ${source_git_tag} || -n ${source_git_tag_semver}) ]] && error "Cannot specify both 'flux.git.branch' and either 'flux.git.tag' or 'flux.git.tag-semver'" && exit 1 # trunk-ignore(shellcheck/SC2310)
+		[[ -n ${source_git_tag} && -n ${source_git_tag_semver} ]] && error "Cannot specify both 'flux.git.tag' and 'flux.git.tag-semver'" && exit 1                                                          # trunk-ignore(shellcheck/SC2310)
+
+		flux_source_args=("--namespace=flux-system" "--url=${source_git_url}")
+		[[ -n ${source_git_branch} ]] && flux_source_args+=("--branch=${source_git_branch}")
+		[[ -n ${source_git_tag} ]] && flux_source_args+=("--tag=${source_git_tag}")
+		[[ -n ${source_git_tag_semver} ]] && flux_source_args+=("--tag-semver=${source_git_tag_semver}")
+		mapfile -t flux_source_extra_args < <(kairos-agent config get flux.source_git_extra_args | sed 's/- //')
+		[[ ${#flux_source_extra_args[@]} -gt 0 ]] && flux_source_args+=("${flux_source_extra_args[@]}")
+
+		flux_kustomization_args=("--namespace=flux-system" "--source=GitRepository/main")
+		[[ -n ${source_git_path} ]] && flux_kustomization_args+=("--path=${source_git_path}")
+		mapfile -t flux_kustomization_extra_args < <(kairos-agent config get flux.kustomization_extra_args | sed 's/- //')
+		[[ ${#flux_kustomization_extra_args[@]} -gt 0 ]] && flux_kustomization_args+=("${flux_kustomization_extra_args[@]}")
+
+		info "Installing FluxCD components"
+		flux install --namespace=flux-system
+
+		info "Creating GitRepository and Kustomization resources"
+		flux create source git main "${flux_source_args[@]}"
+		flux create kustomization main "${flux_kustomization_args[@]}"
+
+		info "FluxCD components installed successfully"
+		exit 0
+	fi
+
+	((retry_attempt = retry_attempt + 1))
+	sleep "${wait_before_retry}"
+done
+
+error "Failed to sync with Flux, timed out (${lease_duration} minutes)"
+exit 4

--- a/catalog/kairos-bundles/flux-sync/run.sh
+++ b/catalog/kairos-bundles/flux-sync/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -x
+
+mkdir -p /usr/local/bin &&
+	cp flux /usr/local/bin/flux
+
+mkdir -p /opt/kairos/bundles/flux-sync &&
+	cp -r flux-sync.sh /opt/kairos/bundles/flux-sync/flux-sync.sh &&
+	chmod +x /opt/kairos/bundles/flux-sync/flux-sync.sh
+
+mkdir -p /etc/systemd/system &&
+	cp flux-sync.service /etc/systemd/system/flux-sync.service
+
+systemctl daemon-reload
+systemctl enable --now flux-sync.service


### PR DESCRIPTION
I'd like to automatically synchronize my repository with Flux when a cluster is created with Kairos.

A community bundle for Flux already exists, but it can only bootstrap a Flux repository and not just synchronize it (requiring secrets like a token or ssh keys).