### PR TITLE
:technologist: Fix eternal diff with `kubectl diff` (because of `applyset`)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -19,6 +19,8 @@ in
   # -- Environment variables
   env.ATLAS_DIR = "${config.env.DEVENV_ROOT}";
 
+  env.DFT_SKIP_UNCHANGED = "true";
+
   env.HELM_CACHE_HOME = "${config.env.DEVENV_ROOT}/.direnv/helm/cache";
   env.HELM_CONFIG_HOME = "${config.env.DEVENV_ROOT}/.direnv/helm/config";
   env.HELM_DATA_HOME = "${config.env.DEVENV_ROOT}/.direnv/helm/data";

--- a/projects/chezmoi.sh/src/infrastructure/.justfile
+++ b/projects/chezmoi.sh/src/infrastructure/.justfile
@@ -3,6 +3,7 @@ kubernetes_configuration := canonicalize(source_directory() / ".." / ".." / ".."
 kubernetes_context := kubernetes_host
 kubernetes_host := "kubernetes.nx.chezmoi.sh"
 kubernetes_applyset := replace_regex(blake3("crossplane/chezmoi.sh"), "[a-f0-9]{32}$", "")
+kubernetes_applyset_id := shell("echo -n $1..ClusterApplySet.kubernetes.chezmoi.sh | openssl dgst -sha256 -binary | openssl base64 -A | tr -d '=' | tr '/+' '_-'", kubernetes_applyset)
 
 [private]
 @default:
@@ -26,6 +27,7 @@ force-apply *kubectl_opts="":
 [doc("Shows the diff of the infrastructure changes")]
 diff:
   kubectl kustomize 'live/production' \
+  | yq '.metadata.labels."applyset.kubernetes.io/part-of" = "applyset-{{ kubernetes_applyset_id }}-v1" | select(. != null)' \
   | KUBECTL_APPLYSET=true \
     kubectl --kubeconfig {{ quote(kubernetes_configuration) }} --context {{ quote(kubernetes_context) }} \
     diff --filename - --server-side --force-conflicts \
@@ -49,12 +51,7 @@ generate-applyset:
       applyset.kubernetes.io/contains-group-kinds: ''
     labels:
       applyset.kubernetes.io/name: "{{ kubernetes_applyset }}"
-      applyset.kubernetes.io/id: applyset-$(
-        echo -n "{{ kubernetes_applyset }}..ClusterApplySet.kubernetes.chezmoi.sh" \
-        | openssl dgst -sha256 -binary \
-        | openssl base64 -A \
-        | tr -d '=' | tr '/+' '_-'
-      )-v1
+      applyset.kubernetes.io/id: applyset-{{ kubernetes_applyset_id }}-v1
     name: "{{ kubernetes_applyset }}"
   spec:
     project: crossplane.chezmoi.sh

--- a/projects/hass/src/infrastructure/.justfile
+++ b/projects/hass/src/infrastructure/.justfile
@@ -3,6 +3,7 @@ kubernetes_configuration := canonicalize(source_directory() / ".." / ".." / ".."
 kubernetes_context := kubernetes_host
 kubernetes_host := "kubernetes.nx.chezmoi.sh"
 kubernetes_applyset := replace_regex(blake3("crossplane/hass.chezmoi.sh"), "[a-f0-9]{32}$", "")
+kubernetes_applyset_id := shell("echo -n $1..ClusterApplySet.kubernetes.chezmoi.sh | openssl dgst -sha256 -binary | openssl base64 -A | tr -d '=' | tr '/+' '_-'", kubernetes_applyset)
 
 [private]
 @default:
@@ -26,6 +27,7 @@ force-apply *kubectl_opts="":
 [doc("Shows the diff of the infrastructure changes")]
 diff:
   kubectl kustomize 'live/production' \
+  | yq '.metadata.labels."applyset.kubernetes.io/part-of" = "applyset-{{ kubernetes_applyset_id }}-v1" | select(. != null)' \
   | KUBECTL_APPLYSET=true \
     kubectl --kubeconfig {{ quote(kubernetes_configuration) }} --context {{ quote(kubernetes_context) }} \
     diff --filename - --server-side --force-conflicts \
@@ -49,12 +51,7 @@ generate-applyset:
       applyset.kubernetes.io/contains-group-kinds: ''
     labels:
       applyset.kubernetes.io/name: "{{ kubernetes_applyset }}"
-      applyset.kubernetes.io/id: applyset-$(
-        echo -n "{{ kubernetes_applyset }}..ClusterApplySet.kubernetes.chezmoi.sh" \
-        | openssl dgst -sha256 -binary \
-        | openssl base64 -A \
-        | tr -d '=' | tr '/+' '_-'
-      )-v1
+      applyset.kubernetes.io/id: applyset-{{ kubernetes_applyset_id }}-v1
     name: "{{ kubernetes_applyset }}"
   spec:
     project: crossplane.nx.chezmoi.sh

--- a/projects/nex.rpi/src/infrastructure/.justfile
+++ b/projects/nex.rpi/src/infrastructure/.justfile
@@ -3,6 +3,7 @@ kubernetes_configuration := canonicalize(source_directory() / ".." / ".." / ".."
 kubernetes_context := kubernetes_host
 kubernetes_host := "kubernetes.nx.chezmoi.sh"
 kubernetes_applyset := replace_regex(blake3("crossplane/nx.chezmoi.sh"), "[a-f0-9]{32}$", "")
+kubernetes_applyset_id := shell("echo -n $1..ClusterApplySet.kubernetes.chezmoi.sh | openssl dgst -sha256 -binary | openssl base64 -A | tr -d '=' | tr '/+' '_-'", kubernetes_applyset)
 
 [private]
 @default:
@@ -26,6 +27,7 @@ force-apply *kubectl_opts="":
 [doc("Shows the diff of the infrastructure changes")]
 diff:
   kubectl kustomize 'live/production' \
+  | yq '.metadata.labels."applyset.kubernetes.io/part-of" = "applyset-{{ kubernetes_applyset_id }}-v1" | select(. != null)' \
   | KUBECTL_APPLYSET=true \
     kubectl --kubeconfig {{ quote(kubernetes_configuration) }} --context {{ quote(kubernetes_context) }} \
     diff --filename - --server-side --force-conflicts \
@@ -49,12 +51,7 @@ generate-applyset:
       applyset.kubernetes.io/contains-group-kinds: ''
     labels:
       applyset.kubernetes.io/name: "{{ kubernetes_applyset }}"
-      applyset.kubernetes.io/id: applyset-$(
-        echo -n "{{ kubernetes_applyset }}..ClusterApplySet.kubernetes.chezmoi.sh" \
-        | openssl dgst -sha256 -binary \
-        | openssl base64 -A \
-        | tr -d '=' | tr '/+' '_-'
-      )-v1
+      applyset.kubernetes.io/id: applyset-{{ kubernetes_applyset_id }}-v1
     name: "{{ kubernetes_applyset }}"
   spec:
     project: crossplane.nx.chezmoi.sh


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve the generation and application of Kubernetes applysets. The most important changes include the introduction of a new `kubernetes_applyset_id` variable and updates to the `diff` and `generate-applyset` tasks to use this new variable.

### Introduction of `kubernetes_applyset_id`:

* Added a new `kubernetes_applyset_id` variable to compute a unique identifier for Kubernetes applysets using a shell command in multiple `justfile` scripts. [[1]](diffhunk://#diff-5d9d0c6e27f126579c3fec436b7c6a1fabcb2993b567692c6c3baa0a663a9364R6) [[2]](diffhunk://#diff-7726fe5ba8459139d8e615536ad1482fcf7221983d91f1d9e9d8931f62d786a0R6) [[3]](diffhunk://#diff-fd92a21dffdc1cefc87b33336a25af9ff74e89641e2c30836a759da06268d3f3R6) [[4]](diffhunk://#diff-bc4a4d8c921068644763b429b083a9e49fe423324a2b8de95428c2f92147bfa8R6-L11) [[5]](diffhunk://#diff-eb5d7af0767ee0d8fa44c4b740bff4cbce435c9ae89e2e6f57b1ab7092999006R6)

### Updates to `diff` task:

* Modified the `diff` task in multiple `justfile` scripts to include the new `kubernetes_applyset_id` in the metadata labels using `yq`. [[1]](diffhunk://#diff-5d9d0c6e27f126579c3fec436b7c6a1fabcb2993b567692c6c3baa0a663a9364R30) [[2]](diffhunk://#diff-7726fe5ba8459139d8e615536ad1482fcf7221983d91f1d9e9d8931f62d786a0R56) [[3]](diffhunk://#diff-fd92a21dffdc1cefc87b33336a25af9ff74e89641e2c30836a759da06268d3f3R30) [[4]](diffhunk://#diff-bc4a4d8c921068644763b429b083a9e49fe423324a2b8de95428c2f92147bfa8R29) [[5]](diffhunk://#diff-eb5d7af0767ee0d8fa44c4b740bff4cbce435c9ae89e2e6f57b1ab7092999006R30)

### Updates to `generate-applyset` task:

* Updated the `generate-applyset` task in multiple `justfile` scripts to use the new `kubernetes_applyset_id` for the `applyset.kubernetes.io/id` label. [[1]](diffhunk://#diff-5d9d0c6e27f126579c3fec436b7c6a1fabcb2993b567692c6c3baa0a663a9364L52-R54) [[2]](diffhunk://#diff-7726fe5ba8459139d8e615536ad1482fcf7221983d91f1d9e9d8931f62d786a0L91-R93) [[3]](diffhunk://#diff-fd92a21dffdc1cefc87b33336a25af9ff74e89641e2c30836a759da06268d3f3L52-R54) [[4]](diffhunk://#diff-bc4a4d8c921068644763b429b083a9e49fe423324a2b8de95428c2f92147bfa8L78-R79) [[5]](diffhunk://#diff-eb5d7af0767ee0d8fa44c4b740bff4cbce435c9ae89e2e6f57b1ab7092999006L52-R54)

### Environment variable addition:

* Added a new environment variable `DFT_SKIP_UNCHANGED` with the value `true` in `devenv.nix` to skip unchanged files during the development process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configuration variable to adjust handling of unchanged files during environment setup.
  - Introduced a centralized mechanism for generating consistent unique identifiers for Kubernetes resource labels, streamlining deployment processes across multiple projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->