### PR TITLE
:bug:(project:nex·rpi): Use workaround on NetworkPolicies to avoid conflict with `labels` transform

### DIFF
--- a/defaults/kubernetes/tailscale/kustomize/security/allow-to-kubernetes-api.networkpolicy.yaml
+++ b/defaults/kubernetes/tailscale/kustomize/security/allow-to-kubernetes-api.networkpolicy.yaml
@@ -19,8 +19,14 @@ spec:
           protocol: TCP
       to:
         - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - kube-system
           podSelector:
-            matchLabels:
-              k8s-app: kube-apiserver
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: k8s-app
+                operator: In
+                values:
+                  - kube-apiserver

--- a/defaults/kubernetes/traefik/kustomize/security/allow-to-kubernetes-api.networkpolicy.yaml
+++ b/defaults/kubernetes/traefik/kustomize/security/allow-to-kubernetes-api.networkpolicy.yaml
@@ -18,8 +18,14 @@ spec:
           protocol: TCP
       to:
         - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - kube-system
           podSelector:
-            matchLabels:
-              k8s-app: kube-apiserver
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: k8s-app
+                operator: In
+                values:
+                  - kube-apiserver

--- a/projects/nx/src/apps/*sso/authelia/security/allow-from-traefik.yaml
+++ b/projects/nx/src/apps/*sso/authelia/security/allow-from-traefik.yaml
@@ -16,11 +16,17 @@ spec:
   ingress:
     - from:
         - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: traefik-system
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - traefik-system
         - podSelector:
-            matchLabels:
-              app.kubernetes.io/name: traefik
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - traefik
       ports:
         - port: 9091
           protocol: TCP

--- a/projects/nx/src/apps/*sso/authelia/security/allow-to-tailscale.yaml
+++ b/projects/nx/src/apps/*sso/authelia/security/allow-to-tailscale.yaml
@@ -16,11 +16,17 @@ spec:
   egress:
     - to:
         - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: tailscale
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - tailscale
         - podSelector:
-            matchLabels:
-              app.kubernetes.io/name: tailscale
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - tailscale
       ports:
         - port: 41641
           protocol: UDP

--- a/projects/nx/src/apps/*sso/security/allow-to-kube-dns.yaml
+++ b/projects/nx/src/apps/*sso/security/allow-to-kube-dns.yaml
@@ -14,11 +14,17 @@ spec:
   egress:
     - to:
         - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - kube-system
         - podSelector:
-            matchLabels:
-              k8s-app: kube-dns
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: k8s-app
+                operator: In
+                values:
+                  - kube-dns
       ports:
         - port: 53
           protocol: UDP

--- a/projects/nx/src/apps/*sso/yaldap/security/allow-from-traefik.yaml
+++ b/projects/nx/src/apps/*sso/yaldap/security/allow-from-traefik.yaml
@@ -16,11 +16,17 @@ spec:
   ingress:
     - from:
         - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: traefik-system
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - traefik-system
         - podSelector:
-            matchLabels:
-              app.kubernetes.io/name: traefik
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - traefik
       ports:
         - port: 8389
           protocol: TCP

--- a/projects/nx/src/apps/home-dashboard/kustomization.yaml
+++ b/projects/nx/src/apps/home-dashboard/kustomization.yaml
@@ -18,7 +18,7 @@ resources:
   - home-dashboard.httproute.yaml
 
   # (SecOps) Network Policies
-  - security/allow-to-cluster.networkpolicy.yaml
+  - security/allow-from-traefik.networkpolicy.yaml
   - security/allow-to-internet.networkpolicy.yaml
 
 configMapGenerator:

--- a/projects/nx/src/apps/home-dashboard/security/allow-from-traefik.networkpolicy.yaml
+++ b/projects/nx/src/apps/home-dashboard/security/allow-from-traefik.networkpolicy.yaml
@@ -16,11 +16,16 @@ spec:
   ingress:
     - from:
         - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: traefik-system
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - traefik-system
           podSelector:
-            matchLabels:
-              app.kubernetes.io/name: traefik
+            matchExpressions: # NOTE: This is a workaround to avoid Kustomization `labels` being applied to the NetworkPolicy
+              - key: app.kubernetes.io/name
+                operator: In
+                values: [traefik]
       ports:
         - port: 8080
           protocol: TCP


### PR DESCRIPTION
This pull request addresses a recurring issue in multiple Kubernetes `NetworkPolicy` configurations by replacing `matchLabels` with `matchExpressions` to prevent unintended `labels` from being applied during Kustomization. Additionally, it includes a file rename and updates to the associated references.

### Changes to NetworkPolicy configurations:

* **Replaced `matchLabels` with `matchExpressions` for namespace and pod selectors**:
  - Updated `defaults/kubernetes/tailscale/kustomize/security/allow-to-kubernetes-api.networkpolicy.yaml` to use `matchExpressions` for `kube-system` and `kube-apiserver` selectors.
  - Updated `defaults/kubernetes/traefik/kustomize/security/allow-to-kubernetes-api.networkpolicy.yaml` to use `matchExpressions` for `kube-system` and `kube-apiserver` selectors.
  - Updated `projects/nx/src/apps/*sso/authelia/security/allow-from-traefik.yaml` to use `matchExpressions` for `traefik-system` and `traefik` selectors.
  - Updated `projects/nx/src/apps/*sso/authelia/security/allow-to-tailscale.yaml` to use `matchExpressions` for `tailscale` namespace and pod selectors.
  - Updated `projects/nx/src/apps/*sso/security/allow-to-kube-dns.yaml` to use `matchExpressions` for `kube-system` and `kube-dns` selectors.
  - Updated `projects/nx/src/apps/*sso/yaldap/security/allow-from-traefik.yaml` to use `matchExpressions` for `traefik-system` and `traefik` selectors.

### File rename and reference update:

* **Renamed and updated references**:
  - Renamed `projects/nx/src/apps/home-dashboard/security/allow-to-cluster.networkpolicy.yaml` to `projects/nx/src/apps/home-dashboard/security/allow-from-traefik.networkpolicy.yaml` and updated its contents to use `matchExpressions` for `traefik-system` and `traefik` selectors.
  - Updated `projects/nx/src/apps/home-dashboard/kustomization.yaml` to reflect the renamed file.