### PR TITLE
:ambulance:(project:amiya.akn): Change all apps branch for main

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -304,10 +304,6 @@ const scopes = [
 		value: "project:maison",
 	},
 	{
-		name: "project:nex·rpi       - Anything related to the Nex·RPI project (chezmoi.sh)",
-		value: "project:nex·rpi",
-	},
-	{
 		name: "gh                    - Anything else",
 		value: "gh",
 	},

--- a/projects/amiya.akn/docs/bootstrap/talos/amiya-akn-01.patch-config.yaml
+++ b/projects/amiya.akn/docs/bootstrap/talos/amiya-akn-01.patch-config.yaml
@@ -62,7 +62,7 @@ cluster:
     cni:
       name: custom
       urls:
-        - https://raw.githubusercontent.com/chezmoi-sh/atlas/refs/heads/migration/move-nx-to-amiya.akn/projects/amiya.akn/docs/bootstrap/talos/manifests/cilium~1.17.3.yaml
+        - https://raw.githubusercontent.com/chezmoi-sh/atlas/refs/heads/main/projects/amiya.akn/docs/bootstrap/talos/manifests/cilium~1.17.3.yaml
   proxy:
     disabled: true
 
@@ -74,8 +74,8 @@ cluster:
   # -- Install extra components
   extraManifests:
     # -- CoreDNS configuration override
-    - https://raw.githubusercontent.com/chezmoi-sh/atlas/refs/heads/migration/move-nx-to-amiya.akn/projects/amiya.akn/docs/bootstrap/talos/manifests/coredns~v1.12.1.yaml
+    - https://raw.githubusercontent.com/chezmoi-sh/atlas/refs/heads/main/projects/amiya.akn/docs/bootstrap/talos/manifests/coredns~v1.12.1.yaml
 
     # -- Metrics Server
-    - https://raw.githubusercontent.com/chezmoi-sh/atlas/refs/heads/migration/move-nx-to-amiya.akn/projects/amiya.akn/docs/bootstrap/talos/manifests/kubelet-serving-cert-approver~0.9.1.yaml
-    - https://raw.githubusercontent.com/chezmoi-sh/atlas/refs/heads/migration/move-nx-to-amiya.akn/projects/amiya.akn/docs/bootstrap/talos/manifests/metrics-server~0.7.2.yaml
+    - https://raw.githubusercontent.com/chezmoi-sh/atlas/refs/heads/main/projects/amiya.akn/docs/bootstrap/talos/manifests/kubelet-serving-cert-approver~0.9.1.yaml
+    - https://raw.githubusercontent.com/chezmoi-sh/atlas/refs/heads/main/projects/amiya.akn/docs/bootstrap/talos/manifests/metrics-server~0.7.2.yaml

--- a/projects/amiya.akn/src/apps/*argocd/seed.application.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/seed.application.yaml
@@ -11,7 +11,7 @@ spec:
   sources:
     - ref: origin
       repoURL: https://github.com/chezmoi-sh/atlas.git
-      targetRevision: migration/move-nx-to-amiya.akn
+      targetRevision: main
       path: projects/amiya.akn/src/apps/*argocd/seed.apps
   syncPolicy:
     syncOptions:

--- a/projects/amiya.akn/src/apps/*argocd/seed.apps/shoot.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/seed.apps/shoot.applicationset.yaml
@@ -36,7 +36,7 @@ spec:
       sources:
         - repoURL: https://github.com/chezmoi-sh/atlas.git
           path: projects/amiya.akn/src/apps/*argocd/shoot.apps
-          targetRevision: migration/move-nx-to-amiya.akn
+          targetRevision: main
 
           kustomize:
             patches:

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/apps.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/apps.applicationset.yaml
@@ -22,7 +22,7 @@ spec:
           - list: { elements: [] } # NOTE: this list will be populated by the `seed` ApplicationSet with the cluster metadata
           - git:
               repoURL: https://github.com/chezmoi-sh/atlas.git
-              revision: migration/move-nx-to-amiya.akn
+              revision: main
               directories:
                 - path: projects/{{ index .metadata.annotations "device.tailscale.com/hostname" | default .name }}/src/apps/*
   template:
@@ -39,7 +39,7 @@ spec:
       sources:
         - repoURL: https://github.com/chezmoi-sh/atlas.git
           path: "{{ .path.path }}"
-          targetRevision: migration/move-nx-to-amiya.akn
+          targetRevision: main
   templatePatch: |
     spec:
       syncPolicy:

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/cert-manager.application.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/cert-manager.application.yaml
@@ -11,7 +11,7 @@ spec:
   sources:
     - ref: origin
       repoURL: https://github.com/chezmoi-sh/atlas.git
-      targetRevision: migration/move-nx-to-amiya.akn
+      targetRevision: main
     - chart: cert-manager
       helm:
         ignoreMissingValueFiles: true

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/external-secrets.application.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/external-secrets.application.yaml
@@ -11,7 +11,7 @@ spec:
   sources:
     - ref: origin
       repoURL: https://github.com/chezmoi-sh/atlas.git
-      targetRevision: migration/move-nx-to-amiya.akn
+      targetRevision: main
     - chart: external-secrets
       helm:
         ignoreMissingValueFiles: true

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/system.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/system.applicationset.yaml
@@ -22,7 +22,7 @@ spec:
           - list: { elements: [] } # NOTE: this list will be populated by the `seed` ApplicationSet with the cluster metadata
           - git:
               repoURL: https://github.com/chezmoi-sh/atlas.git
-              revision: migration/move-nx-to-amiya.akn
+              revision: main
               directories:
                 - path: projects/{{ index .metadata.annotations "device.tailscale.com/hostname" | default .name }}/src/infrastructure/kubernetes/*
 
@@ -49,7 +49,7 @@ spec:
       sources:
         - repoURL: https://github.com/chezmoi-sh/atlas.git
           path: "{{ .path.path }}"
-          targetRevision: migration/move-nx-to-amiya.akn
+          targetRevision: main
       syncPolicy:
         syncOptions:
           - CreateNamespace=true

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/tailscale.application.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/tailscale.application.yaml
@@ -12,7 +12,7 @@ spec:
     # Install Tailscale default resources (ProxyClass, NetworkPolicy, etc.)
     - ref: origin
       repoURL: https://github.com/chezmoi-sh/atlas.git
-      targetRevision: migration/move-nx-to-amiya.akn
+      targetRevision: main
       path: defaults/kubernetes/tailscale/kustomize
 
       kustomize:

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/traefik.application.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/traefik.application.yaml
@@ -11,7 +11,7 @@ spec:
   sources:
     - ref: origin
       repoURL: https://github.com/chezmoi-sh/atlas.git
-      targetRevision: migration/move-nx-to-amiya.akn
+      targetRevision: main
       path: defaults/kubernetes/traefik/kustomize
 
       kustomize:

--- a/projects/amiya.akn/src/apps/*crossplane/crossplane.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/*crossplane/crossplane.applicationset.yaml
@@ -18,7 +18,7 @@ spec:
   generators:
     - git:
         repoURL: https://github.com/chezmoi-sh/atlas.git
-        revision: migration/move-nx-to-amiya.akn
+        revision: main
         directories:
           - path: projects/*/src/infrastructure/crossplane
   template:
@@ -35,7 +35,7 @@ spec:
       sources:
         - repoURL: https://github.com/chezmoi-sh/atlas.git
           path: "{{ .path.path }}"
-          targetRevision: migration/move-nx-to-amiya.akn
+          targetRevision: main
       syncPolicy:
         automated:
           prune: true


### PR DESCRIPTION
This pull request updates multiple configuration files to replace references to the `migration/move-nx-to-amiya.akn` branch with the `main` branch.

### Updates to Branch References:

* **Talos Configuration**:
  - Updated URLs for CNI and extra manifests in `amiya-akn-01.patch-config.yaml` to reference the `main` branch instead of `migration/move-nx-to-amiya.akn`. [[1]](diffhunk://#diff-d4941dd94f2146edf1c9de8b11a8e163a82c3fbb6cb13afb02b8d42cb2e6bf51L65-R65) [[2]](diffhunk://#diff-d4941dd94f2146edf1c9de8b11a8e163a82c3fbb6cb13afb02b8d42cb2e6bf51L77-R81)

* **ArgoCD Applications**:
  - Changed `targetRevision` in multiple ArgoCD application and ApplicationSet YAML files to use the `main` branch:
    - `seed.application.yaml`
    - `shoot.applicationset.yaml`
    - `apps.applicationset.yaml` [[1]](diffhunk://#diff-d6f5830c3b3d1ee5b26b91dc90df4dca42435431c3f4b622706e5fb0f546d74eL25-R25) [[2]](diffhunk://#diff-d6f5830c3b3d1ee5b26b91dc90df4dca42435431c3f4b622706e5fb0f546d74eL42-R42)
    - `cert-manager.application.yaml`
    - `external-secrets.application.yaml`
    - `system.applicationset.yaml` [[1]](diffhunk://#diff-a988ba48c1dc20aed52de1be747d88e18fab1f4142862241d2b2039f20d3b4aaL25-R25) [[2]](diffhunk://#diff-a988ba48c1dc20aed52de1be747d88e18fab1f4142862241d2b2039f20d3b4aaL52-R52)
    - `tailscale.application.yaml`
    - `traefik.application.yaml`

* **Crossplane Applications**:
  - Updated `revision` and `targetRevision` in `crossplane.applicationset.yaml` to point to the `main` branch. [[1]](diffhunk://#diff-1193732f682804281896b3114800fbcabe9c0759d17de472abb55e8595c146dfL21-R21) [[2]](diffhunk://#diff-1193732f682804281896b3114800fbcabe9c0759d17de472abb55e8595c146dfL38-R38)