### PR TITLE
:bug:(project:amiya.akn): Reduce the number of snapshots from 24 to 4

### DIFF
--- a/projects/amiya.akn/src/apps/*sso/authelia/kustomization.yaml
+++ b/projects/amiya.akn/src/apps/*sso/authelia/kustomization.yaml
@@ -40,7 +40,7 @@ patches:
         path: /metadata/labels/recurring-job.longhorn.io~1source
         value: enabled
       - op: add
-        path: /metadata/labels/recurring-job-group.longhorn.io~1hourly
+        path: /metadata/labels/recurring-job-group.longhorn.io~1auto-snapshots
         value: enabled
       - op: add
         path: /metadata/labels/recurring-job-group.longhorn.io~1daily

--- a/projects/amiya.akn/src/infrastructure/kubernetes/*longhorn/default.recurringjobs.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/*longhorn/default.recurringjobs.yaml
@@ -2,17 +2,18 @@
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
-  name: hourly-snapshot
+  name: 6h-snapshots
 spec:
   concurrency: 1
-  cron: 0 * * * *
+  cron: 0 */6 * * *
   groups:
     - default
-    - hourly
+    - auto-snapshots
   labels:
-    snapshot.longhorn.io/type: hourly
-  name: hourly-snapshot
-  retain: 24
+    snapshot.longhorn.io/type: auto
+    snapshot.longhorn.io/interval: 6h
+  name: 6h-snapshots
+  retain: 4
   task: snapshot
 ---
 apiVersion: longhorn.io/v1beta2


### PR DESCRIPTION
This pull request updates the recurring job configuration for Longhorn snapshots to adjust the scheduling and naming conventions. The most important changes include renaming the recurring job from "hourly-snapshot" to "6h-snapshots," updating the cron schedule to every 6 hours, and modifying associated labels and retention settings.

### Changes to recurring job configuration:

* Updated the recurring job name from `hourly-snapshot` to `6h-snapshots` in `projects/amiya.akn/src/infrastructure/kubernetes/*longhorn/default.recurringjobs.yaml`.
* Changed the cron schedule for the recurring job from hourly (`0 * * * *`) to every 6 hours (`0 */6 * * *`) in `projects/amiya.akn/src/infrastructure/kubernetes/*longhorn/default.recurringjobs.yaml`.
* Adjusted the retention policy for snapshots from 24 to 4 and updated the group label from `hourly` to `auto-snapshots` in `projects/amiya.akn/src/infrastructure/kubernetes/*longhorn/default.recurringjobs.yaml`.

### Changes to metadata labels:

* Updated the label path from `recurring-job-group.longhorn.io~1hourly` to `recurring-job-group.longhorn.io~16h-snapshots` in `projects/amiya.akn/src/apps/*sso/authelia/kustomization.yaml`.